### PR TITLE
Fix isSameNode check in IE11

### DIFF
--- a/assets/js/phoenix_live_view.js
+++ b/assets/js/phoenix_live_view.js
@@ -1098,7 +1098,7 @@ class DOMPatch {
         DOM.copyPrivates(toEl, fromEl)
         DOM.discardError(targetContainer, toEl)
 
-        if(fromEl.isSameNode(focused) && DOM.isFormInput(fromEl) && !(fromEl.multiple === true)){
+        if(focused && fromEl.isSameNode(focused) && DOM.isFormInput(fromEl) && !(fromEl.multiple === true)){
           this.trackBefore("updated", fromEl, toEl)
           DOM.mergeFocusedInput(fromEl, toEl)
           DOM.syncAttrsToProps(fromEl)


### PR DESCRIPTION
Call of `node.isSameNode(null)` in IE11 leads to an error `Invalid pointer`

`focused` can be null because [document.activeElement can be null](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/activeElement)